### PR TITLE
Validate input ref for variant format

### DIFF
--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -2,3 +2,4 @@ flask
 flask_cors
 flask_talisman
 gunicorn
+pyfaidx~=0.8

--- a/service/server.py
+++ b/service/server.py
@@ -297,7 +297,7 @@ def validate_variant_input(hg, chrom, pos, ref):
     reference_genome = Fasta(FASTA_PATHS[reference_genome_key])
     ref_seq = reference_genome[chrom][pos-1:pos-1+len(ref)].seq
 
-    if ref_seq != ref:
+    if ref_seq.lower() != ref.lower():
         raise ValidationError(f"Ref {ref} given, but reference genome has {ref_seq} at this position")
 
 


### PR DESCRIPTION
This introduces a validation step that checks if the given `ref` parameter matches the reference genome for the given position. This validation is only done when an additional `strict` parameter is provided, to preserve backwards compatibility.